### PR TITLE
add aws session token to aws demos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,9 +212,11 @@ get-creds-%:
 .%-aws-access-key: var_description = AWS access key ID
 .%-aws-secret-access-key: var_name = AWS_SECRET_ACCESS_KEY
 .%-aws-secret-access-key: var_description = AWS secret access key
+.%-aws-session-token: var_name = AWS_SESSION_TOKEN
+.%-aws-session-token: var_description = AWS session token
 
 .PHONY: setup-aws-creds
-setup-aws-creds: .check-variable-aws-access-key .check-variable-aws-secret-access-key ## Setup AWS credentials
+setup-aws-creds: .check-variable-aws-access-key .check-variable-aws-secret-access-key .check-variable-aws-session-token ## Setup AWS credentials
 setup-aws-creds: ## Setup AWS credentials
 	envsubst < setup/aws-credentials.yaml | kubectl apply -f -
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This assumes that you already have configured the required [AWS IAM Roles](https
     ```shell
     export AWS_ACCESS_KEY_ID="AWS Access Key ID"
     export AWS_SECRET_ACCESS_KEY="AWS Secret Access Key"
+    export AWS_SESSION_TOKEN="AWS Session Token"
     ````
 2. By default, it will provision all resources in the `us-west-2` AWS region. If you want to change this, export `AWS_REGION` environment variable:
     ```shell

--- a/setup/aws-credentials.yaml
+++ b/setup/aws-credentials.yaml
@@ -19,6 +19,7 @@ type: Opaque
 stringData:
   AccessKeyID: ${AWS_ACCESS_KEY_ID}
   SecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
+  SessionToken: ${AWS_SESSION_TOKEN}
 ---
 apiVersion: hmc.mirantis.com/v1alpha1
 kind: Credential


### PR DESCRIPTION
AWS session token is missing from credentials setup, through it is required to use with SSO authentication