### PR TITLE
Limit AWS availability zones for cost-efficient aws demo clusters

### DIFF
--- a/templates/cluster/demo-aws-standalone-cp-0.0.1/templates/awscluster.yaml
+++ b/templates/cluster/demo-aws-standalone-cp-0.0.1/templates/awscluster.yaml
@@ -12,6 +12,8 @@ spec:
   controlPlaneLoadBalancer:
     healthCheckProtocol: TCP
   network:
+    vpc:
+      availabilityZoneUsageLimit: {{ .Values.network.vpc.availabilityZoneUsageLimit }}
     additionalControlPlaneIngressRules:
       - description: "k0s controller join API"
         protocol: tcp

--- a/templates/cluster/demo-aws-standalone-cp-0.0.1/values.yaml
+++ b/templates/cluster/demo-aws-standalone-cp-0.0.1/values.yaml
@@ -14,6 +14,9 @@ clusterNetwork:
 region: ""
 sshKeyName: ""
 publicIP: false
+network:
+  vpc:
+    availabilityZoneUsageLimit: 1
 bastion:
   enabled: false
   disableIngressRules: false

--- a/templates/cluster/demo-aws-standalone-cp-0.0.2/templates/awscluster.yaml
+++ b/templates/cluster/demo-aws-standalone-cp-0.0.2/templates/awscluster.yaml
@@ -12,6 +12,8 @@ spec:
   controlPlaneLoadBalancer:
     healthCheckProtocol: TCP
   network:
+    vpc:
+      availabilityZoneUsageLimit: {{ .Values.network.vpc.availabilityZoneUsageLimit }}
     additionalControlPlaneIngressRules:
       - description: "k0s controller join API"
         protocol: tcp

--- a/templates/cluster/demo-aws-standalone-cp-0.0.2/values.yaml
+++ b/templates/cluster/demo-aws-standalone-cp-0.0.2/values.yaml
@@ -14,6 +14,9 @@ clusterNetwork:
 region: ""
 sshKeyName: ""
 publicIP: false
+network:
+  vpc:
+    availabilityZoneUsageLimit: 1
 bastion:
   enabled: false
   disableIngressRules: false


### PR DESCRIPTION
By default, deploying a demo cluster on AWS creates private subnets across all available availability zones (typically 3). This leads to the creation of 3 NAT Gateways and 3 Elastic IPs, which can significantly increase costs and quickly exhaust Elastic IP quotas.

This PR updates the AWS ClusterTemplate to include an option for limiting the number of availability zones used. The default is now set to 1, which is a reasonable choice for demo purposes.

If we want to use more AZs, we can just explicitly configure in the ClusterDeployment
```yaml
apiVersion: hmc.mirantis.com/v1alpha1
kind: ClusterDeployment
metadata:
  name: ${NAMESPACE}-aws-${CLUSTERNAME}${UNIQUE_SUFFIX}
  namespace: ${NAMESPACE}
spec:
  template: demo-aws-standalone-cp-0.0.1
  credential: aws-cluster-identity-cred
  config:
    region: ${AWS_REGION}
    network:
      vpc:
        availabilityZoneUsageLimit: 3
    publicIP: true
    controlPlaneNumber: 1
    workersNumber: 2
    controlPlane:
      instanceType: t3.small
    worker:
      instanceType: t3.small
```

Additionally, it may improve cluster creation times by reducing the resources and infrastructure that need to be provisioned.